### PR TITLE
fix packages.dhall upstream package-set URL

### DIFF
--- a/example-purescript-package/packages.dhall
+++ b/example-purescript-package/packages.dhall
@@ -5,6 +5,6 @@ let upstream =
       -- Note that you won't need to use a special package set if the
       -- purescript package-set repo starts generating package-sets that include
       -- Nix-compatible hashes.
-      https://raw.githubusercontent.com/cdepillabout/package-sets/add-hashes/packages-with-hashes.dhall sha256:1b57a695086213bbff7b9a692bc1049343ae962cbacb5bc5dd9f19c0bf75bf80
+      https://raw.githubusercontent.com/cdepillabout/package-sets/add-hashes-example-package-set/packages-with-hashes.dhall sha256:1b57a695086213bbff7b9a692bc1049343ae962cbacb5bc5dd9f19c0bf75bf80
 
 in  upstream


### PR DESCRIPTION
Hey @cdepillabout I was trying to get this working and was running into issues:

```bash
> nixFlakes build .#example-purescript-package --impure
warning: Git tree '/home/dd/code/purescript2nix.cdepillabout' is dirty
copying path '/nix/store/qbdsd82q5fyr0v31cvfxda0n0h7jh03g-libunistring-0.9.10' from 'https://cache.nixos.org'...
<snip>
copying path '/nix/store/0yzqb4p2s29hdxaz43i5hd39qcp2pl5z-dhall-1.39.0' from 'https://cache.nixos.org'...
building '/nix/store/iwhcq9wwhc69gcp63lvwlb5nzc8l4sr9-store.dhall.drv'...
building '/nix/store/6p9ql48fdwfdxvmlfjp0ff90hc85bimj-packages-with-hashes.dhall.drv'...
builder for '/nix/store/6p9ql48fdwfdxvmlfjp0ff90hc85bimj-packages-with-hashes.dhall.drv' failed with exit code 1; last 10 log lines:
  dhall: 
  Error: Invalid input
  
  (input):1:1:
    |
  1 | <empty line>
    | ^
  unexpected end of input
  expecting #!, expression, or whitespace
cannot build derivation '/nix/store/5fgr93ybpf3d0rsnd2gn2j6gi2r5cjmb-packages-with-hashes.dhall-cache.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/avdmrnbg8rs438vmjijpjdm4qzf29g4z-store.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/gbjh9wc3bnc2i7a2w99dd2fi0hz6363j-dhall-compiled-package.nix.drv': 1 dependencies couldn't be built
error: build of '/nix/store/gbjh9wc3bnc2i7a2w99dd2fi0hz6363j-dhall-compiled-package.nix.drv' failed
(use '--show-trace' to show detailed location information)
```

Doing the same but via nix-build told me what the problem actually was:

```bash
> nix-build ./nix -A example-purescript-package
building '/nix/store/6p9ql48fdwfdxvmlfjp0ff90hc85bimj-packages-with-hashes.dhall.drv'...

Warning: Could not get or create the default cache directory:

↳ /homeless-shelter/.cache/dhall

You can enable caching by creating it if needed and setting read,
write and search permissions on it or providing another cache base
directory by setting the $XDG_CACHE_HOME environment variable.


dhall:
Error: Remote file not found

HTTP status code: 404

URL: https://raw.githubusercontent.com/cdepillabout/package-sets/add-hashes/packages-with-hashes.dhall

Message:

1 404: Not Found

dhall:
Error: Invalid input

(input):1:1:
  |
1 | <empty line>
  | ^
unexpected end of input
expecting #!, expression, or whitespace

builder for '/nix/store/6p9ql48fdwfdxvmlfjp0ff90hc85bimj-packages-with-hashes.dhall.drv' failed with exit code 1
cannot build derivation '/nix/store/5fgr93ybpf3d0rsnd2gn2j6gi2r5cjmb-packages-with-hashes.dhall-cache.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/avdmrnbg8rs438vmjijpjdm4qzf29g4z-store.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/gbjh9wc3bnc2i7a2w99dd2fi0hz6363j-dhall-compiled-package.nix.drv': 1 dependencies couldn't be built
error: build of '/nix/store/gbjh9wc3bnc2i7a2w99dd2fi0hz6363j-dhall-compiled-package.nix.drv' failed
(use '--show-trace' to show detailed location information)
> 
```

[I've read up on the state of affairs wrt the PS Registry](https://functor.tokyo/blog/2021-12-10-purescript-package-set-with-hashes#future-of-purescript-package-sets) and seen your other issues, in particular [this one](https://github.com/cdepillabout/purescript2nix/issues/4), so I recognize this is a temporary fix most likely, but I figured it was handy in the short term regardless.

Incidentally I'd love to help. Can you tell me what I'd need to get going with #4, from your perspective? It seems like the Registry is still a [work in progress](https://github.com/purescript/registry/pull/279), but I'm still reading up on it.