### PR TITLE
Pick purescript compiler based on version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "easy-purescript-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671011575,
+        "narHash": "sha256-tESal32bcqqdZO+aKnBzc1GoL2mtnaDtj2y7ociCRGA=",
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "rev": "11d3bd58ce6e32703bf69cec04dc7c38eabe14ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinwoo",
+        "repo": "easy-purescript-nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1671995294,
@@ -49,6 +65,7 @@
     },
     "root": {
       "inputs": {
+        "easy-purescript-nix": "easy-purescript-nix",
         "nixpkgs": "nixpkgs",
         "purescript-registry": "purescript-registry",
         "purescript-registry-index": "purescript-registry-index"

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,10 @@
 
   inputs.purescript-registry-index.url = "github:purescript/registry-index";
   inputs.purescript-registry-index.flake = false;
+  inputs.easy-purescript-nix.url = "github:justinwoo/easy-purescript-nix";
+  inputs.easy-purescript-nix.flake = false;
 
-  outputs = { self, nixpkgs, purescript-registry, purescript-registry-index }:
+  outputs = { self, nixpkgs, purescript-registry, purescript-registry-index, easy-purescript-nix }:
     let
       # System types to support.
       supportedSystems = [
@@ -33,7 +35,7 @@
       # A Nixpkgs overlay.  This contains the purescript2nix function that
       # end-users will want to use.
       overlay = import ./nix/overlay.nix {
-        inherit purescript-registry purescript-registry-index;
+        inherit purescript-registry purescript-registry-index easy-purescript-nix;
       };
 
       packages = forAllSystems (system: {

--- a/nix/build-support/purescript2nix/get-compiler-by-version.nix
+++ b/nix/build-support/purescript2nix/get-compiler-by-version.nix
@@ -1,9 +1,14 @@
-{ easy-ps, lib }: version:
+{ easy-ps, lib, purescript }: version:
 
 let
   major = lib.versions.major version;
   minor = lib.versions.minor version;
   patch = lib.versions.patch version;
   compiler-name = "purs-${major}_${minor}_${patch}";
+  fallback = builtins.trace ''
+    Couldn't select purescript compiler with version ${version}.
+    Using version ${purescript.version} from nixpkgs instead.
+  ''
+    purescript;
 in
-easy-ps.${compiler-name}
+  easy-ps.${compiler-name} or fallback

--- a/nix/build-support/purescript2nix/get-compiler-by-version.nix
+++ b/nix/build-support/purescript2nix/get-compiler-by-version.nix
@@ -1,0 +1,9 @@
+{ easy-ps, lib }: version:
+
+let
+  major = lib.versions.major version;
+  minor = lib.versions.minor version;
+  patch = lib.versions.patch version;
+  compiler-name = "purs-${major}_${minor}_${patch}";
+in
+easy-ps.${compiler-name}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,14 @@
-{ purescript-registry, purescript-registry-index }: final: prev: {
+{ purescript-registry, purescript-registry-index, easy-purescript-nix }: final: prev:
+let easy-ps = import easy-purescript-nix {
+  pkgs = final;
+};
+in
+{
 
+  # This function selects the purescript compiler to use when building in purescript2nix based on the requested compiler version.
+  purescript2nix-compiler = final.callPackage ./build-support/purescript2nix/get-compiler-by-version.nix {
+    inherit easy-ps;
+  };
   # This is the purescript2nix function.  This makes it easy to build a
   # PureScript package with Nix.  This is the main function provided by this
   # repo.


### PR DESCRIPTION
This PR picks the purescript compiler based on the version specified in the registry package set.

Closes #9 