### PR TITLE
Don't generate documentation on CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
         # ./example-purescript-package. But most users can ignore this.
         purescript-dev-shell = (nixpkgsFor.${system}.purescript2nix {
           subdir = "example-registry-package";
-          src = ./.;
+          src = ./examples;
         }).develop;
         spago =
           let

--- a/nix/build-support/purescript2nix/build-package-set.nix
+++ b/nix/build-support/purescript2nix/build-package-set.nix
@@ -37,7 +37,7 @@ let
       compiler
       fetch-sources
       backendCommand;
-    withDocs = true;
+    withDocs = false;
   };
   pkgs = make-pkgs pkgs closure.packages;
   paths = lib.mapAttrsToList (name: path: { inherit name path; }) pkgs;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -39,7 +39,7 @@ let
 
   example-registry-package = pkgs.purescript2nix {
     subdir = "example-registry-package";
-    src = ../.;
+    src = ../examples;
   };
   example-registry-package-test = example-registry-package.test;
 in


### PR DESCRIPTION
Generating the documentation makes the Github Actions runner run out of disk space.