### PR TITLE
Use workspace.packageSet in package-set-config.

### DIFF
--- a/nix/build-support/purifix/build-purifix-package.nix
+++ b/nix/build-support/purifix/build-purifix-package.nix
@@ -26,7 +26,8 @@ let
   linkFiles = callPackage ./link-files.nix { };
   workspace = package-config.workspace;
   yaml = package-config.config;
-  package-set-config = workspace.package_set or workspace.set;
+  package-set-config = 
+    workspace.packageSet or workspace.package_set or workspace.set;
   extra-packages = (workspace.extra_packages or { }) // (lib.mapAttrs (_: x: x // { isLocal = true; }) localPackages);
   inherit (callPackage ./get-package-set.nix
     { inherit fromYAML purescript-registry purescript-registry-index; }


### PR DESCRIPTION
Running `spago build --migrate` with spago v0.93.41, the most recent version, changed my spago.yaml's `workspace.package_set` to `workspace.packageSet`. So, I guess that's the new default.